### PR TITLE
ci: automatically publish package assets on release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,14 @@ stages:
           - download: current
             displayName: 'Download package artifact'
             artifact: 'Development Hub'
+          - task: ArchiveFiles@2
+            displayName: 'Zip package artifact'
+            inputs:
+              rootFolderOrFile: '$(Pipeline.Workspace)/Development Hub'
+              includeRootFolder: true
+              archiveType: 'zip'
+              archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
+              replaceExistingArchive: true
           - task: GitHubRelease@1
             displayName: Create GitHub release
             inputs:
@@ -46,9 +54,7 @@ stages:
               tagSource: 'userSpecifiedTag'
               tag: 'v$(SemVer)'
               releaseNotesSource: 'inline'
-              assets: |
-                $(Pipeline.Workspace)/Development Hub/**/*.zip
-                $(Pipeline.Workspace)/Development Hub/**/*.md
+              assets: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
               isPreRelease: true
               changeLogCompareToRelease: 'lastNonDraftRelease'
               changeLogType: 'commitBased'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,19 +33,22 @@ stages:
         variables: 
           SemVer: $[ stageDependencies.Build.BuildJob.outputs['OutputSemVerTask.SemVer'] ]
         steps:
-        - task: GitHubRelease@1
-          displayName: Create GitHub release
-          inputs:
-            gitHubConnection: 'GitHub (ewingjm)'
-            repositoryName: '$(Build.Repository.Name)'
-            action: 'create'
-            target: '$(Build.SourceVersion)'
-            tagSource: 'userSpecifiedTag'
-            tag: 'v$(SemVer)'
-            releaseNotesSource: 'inline'
-            assets: |
-              $(Pipeline.Workspace)/Development Hub/*.zip
-              $(Pipeline.Workspace)/Development Hub/*.md
-            isPreRelease: true
-            changeLogCompareToRelease: 'lastNonDraftRelease'
-            changeLogType: 'commitBased'
+          - download: current
+            displayName: 'Download package artifact'
+            artifact: 'Development Hub'
+          - task: GitHubRelease@1
+            displayName: Create GitHub release
+            inputs:
+              gitHubConnection: 'GitHub (ewingjm)'
+              repositoryName: '$(Build.Repository.Name)'
+              action: 'create'
+              target: '$(Build.SourceVersion)'
+              tagSource: 'userSpecifiedTag'
+              tag: 'v$(SemVer)'
+              releaseNotesSource: 'inline'
+              assets: |
+                $(Pipeline.Workspace)/Development Hub/**/*.zip
+                $(Pipeline.Workspace)/Development Hub/**/*.md
+              isPreRelease: true
+              changeLogCompareToRelease: 'lastNonDraftRelease'
+              changeLogType: 'commitBased'


### PR DESCRIPTION
## Purpose
The automated release process should provide the binary assets (e.g. the zipped package folder).

## Approach
Zips the package folder and attaches it to the release as an asset.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
