### PR TITLE
ci: move release job dependencies to stage level

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,13 +23,13 @@ stages:
       environmentVariableGroup: 'Environment - Test'
   - stage: CreateRelease
     displayName: 'Create release'
+    dependsOn:
+      - 'Build'
+      - 'Test'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     jobs:
       - job: CreateReleaseJob
         displayName: 'Create release'
-        dependsOn:
-          - 'Build'
-          - 'Test'
         variables: 
           SemVer: $[ stageDependencies.Build.BuildJob.outputs['OutputSemVerTask.SemVer'] ]
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ stages:
     displayName: 'Create release'
     dependsOn:
       - 'Build'
-      # - 'Test'
+      - 'Test'
     condition: succeeded()
     jobs:
       - job: CreateReleaseJob
@@ -44,17 +44,17 @@ stages:
               archiveType: 'zip'
               archiveFile: '$(Build.ArtifactStagingDirectory)/Development Hub v$(SemVer).zip'
               replaceExistingArchive: true
-          # - task: GitHubRelease@1
-          #   displayName: Create GitHub release
-          #   inputs:
-          #     gitHubConnection: 'GitHub (ewingjm)'
-          #     repositoryName: '$(Build.Repository.Name)'
-          #     action: 'create'
-          #     target: '$(Build.SourceVersion)'
-          #     tagSource: 'userSpecifiedTag'
-          #     tag: 'v$(SemVer)'
-          #     releaseNotesSource: 'inline'
-          #     assets: '$(Build.ArtifactStagingDirectory)/Development Hub v$(SemVer).zip'
-          #     isPreRelease: true
-          #     changeLogCompareToRelease: 'lastNonDraftRelease'
-          #     changeLogType: 'commitBased'
+          - task: GitHubRelease@1
+            displayName: Create GitHub release
+            inputs:
+              gitHubConnection: 'GitHub (ewingjm)'
+              repositoryName: '$(Build.Repository.Name)'
+              action: 'create'
+              target: '$(Build.SourceVersion)'
+              tagSource: 'userSpecifiedTag'
+              tag: 'v$(SemVer)'
+              releaseNotesSource: 'inline'
+              assets: '$(Build.ArtifactStagingDirectory)/Development Hub v$(SemVer).zip'
+              isPreRelease: true
+              changeLogCompareToRelease: 'lastNonDraftRelease'
+              changeLogType: 'commitBased'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ stages:
               rootFolderOrFile: '$(Pipeline.Workspace)/Development Hub'
               includeRootFolder: true
               archiveType: 'zip'
-              archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
+              archiveFile: '$(Build.ArtifactStagingDirectory)/Development Hub v$(SemVer).zip'
               replaceExistingArchive: true
           # - task: GitHubRelease@1
           #   displayName: Create GitHub release
@@ -54,7 +54,7 @@ stages:
           #     tagSource: 'userSpecifiedTag'
           #     tag: 'v$(SemVer)'
           #     releaseNotesSource: 'inline'
-          #     assets: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
+          #     assets: '$(Build.ArtifactStagingDirectory)/Development Hub v$(SemVer).zip'
           #     isPreRelease: true
           #     changeLogCompareToRelease: 'lastNonDraftRelease'
           #     changeLogType: 'commitBased'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ stages:
     dependsOn:
       - 'Build'
       # - 'Test'
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: succeeded()
     jobs:
       - job: CreateReleaseJob
         displayName: 'Create release'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,17 +44,17 @@ stages:
               archiveType: 'zip'
               archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
               replaceExistingArchive: true
-          - task: GitHubRelease@1
-            displayName: Create GitHub release
-            inputs:
-              gitHubConnection: 'GitHub (ewingjm)'
-              repositoryName: '$(Build.Repository.Name)'
-              action: 'create'
-              target: '$(Build.SourceVersion)'
-              tagSource: 'userSpecifiedTag'
-              tag: 'v$(SemVer)'
-              releaseNotesSource: 'inline'
-              assets: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
-              isPreRelease: true
-              changeLogCompareToRelease: 'lastNonDraftRelease'
-              changeLogType: 'commitBased'
+          # - task: GitHubRelease@1
+          #   displayName: Create GitHub release
+          #   inputs:
+          #     gitHubConnection: 'GitHub (ewingjm)'
+          #     repositoryName: '$(Build.Repository.Name)'
+          #     action: 'create'
+          #     target: '$(Build.SourceVersion)'
+          #     tagSource: 'userSpecifiedTag'
+          #     tag: 'v$(SemVer)'
+          #     releaseNotesSource: 'inline'
+          #     assets: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
+          #     isPreRelease: true
+          #     changeLogCompareToRelease: 'lastNonDraftRelease'
+          #     changeLogType: 'commitBased'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ stages:
     dependsOn:
       - 'Build'
       - 'Test'
-    condition: succeeded()
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     jobs:
       - job: CreateReleaseJob
         displayName: 'Create release'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,17 +44,17 @@ stages:
               archiveType: 'zip'
               archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
               replaceExistingArchive: true
-          # - task: GitHubRelease@1
-          #   displayName: Create GitHub release
-          #   inputs:
-          #     gitHubConnection: 'GitHub (ewingjm)'
-          #     repositoryName: '$(Build.Repository.Name)'
-          #     action: 'create'
-          #     target: '$(Build.SourceVersion)'
-          #     tagSource: 'userSpecifiedTag'
-          #     tag: 'v$(SemVer)'
-          #     releaseNotesSource: 'inline'
-          #     assets: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
-          #     isPreRelease: true
-          #     changeLogCompareToRelease: 'lastNonDraftRelease'
-          #     changeLogType: 'commitBased'
+          - task: GitHubRelease@1
+            displayName: Create GitHub release
+            inputs:
+              gitHubConnection: 'GitHub (ewingjm)'
+              repositoryName: '$(Build.Repository.Name)'
+              action: 'create'
+              target: '$(Build.SourceVersion)'
+              tagSource: 'userSpecifiedTag'
+              tag: 'v$(SemVer)'
+              releaseNotesSource: 'inline'
+              assets: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
+              isPreRelease: true
+              changeLogCompareToRelease: 'lastNonDraftRelease'
+              changeLogType: 'commitBased'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ stages:
     displayName: 'Create release'
     dependsOn:
       - 'Build'
-      - 'Test'
+      # - 'Test'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     jobs:
       - job: CreateReleaseJob
@@ -44,17 +44,17 @@ stages:
               archiveType: 'zip'
               archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
               replaceExistingArchive: true
-          - task: GitHubRelease@1
-            displayName: Create GitHub release
-            inputs:
-              gitHubConnection: 'GitHub (ewingjm)'
-              repositoryName: '$(Build.Repository.Name)'
-              action: 'create'
-              target: '$(Build.SourceVersion)'
-              tagSource: 'userSpecifiedTag'
-              tag: 'v$(SemVer)'
-              releaseNotesSource: 'inline'
-              assets: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
-              isPreRelease: true
-              changeLogCompareToRelease: 'lastNonDraftRelease'
-              changeLogType: 'commitBased'
+          # - task: GitHubRelease@1
+          #   displayName: Create GitHub release
+          #   inputs:
+          #     gitHubConnection: 'GitHub (ewingjm)'
+          #     repositoryName: '$(Build.Repository.Name)'
+          #     action: 'create'
+          #     target: '$(Build.SourceVersion)'
+          #     tagSource: 'userSpecifiedTag'
+          #     tag: 'v$(SemVer)'
+          #     releaseNotesSource: 'inline'
+          #     assets: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
+          #     isPreRelease: true
+          #     changeLogCompareToRelease: 'lastNonDraftRelease'
+          #     changeLogType: 'commitBased'


### PR DESCRIPTION
## Purpose
The release stage dependencies were erroneously at job-level rather than stage-level.

## Approach
Moves the dependencies to stage-level

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
