### PR TITLE
fix: approved by always solution merge creator

### DIFF
--- a/src/solutions/devhub_DevelopmentHub_Develop/Extract/Workflows/Approve-38601740-AE0B-46AF-8809-5D402B5A0A02.xaml
+++ b/src/solutions/devhub_DevelopmentHub_Develop/Extract/Workflows/Approve-38601740-AE0B-46AF-8809-5D402B5A0A02.xaml
@@ -23,6 +23,22 @@
   </this:XrmWorkflow38601740ae0b46af88095d402b5a0a02.Target>
   <mva:VisualBasic.Settings>Assembly references and imported namespaces for internal implementation</mva:VisualBasic.Settings>
   <mxswa:Workflow>
+    <mxswa:SetState DisplayName="SetStateStep4: Set status reason to 'Approved'" Entity="[InputEntities(&quot;primaryEntity&quot;)]" EntityId="[InputEntities(&quot;primaryEntity&quot;).Id]" EntityName="devhub_solutionmerge">
+      <mxswa:SetState.State>
+        <InArgument x:TypeArguments="mxs:OptionSetValue">
+          <mxswa:ReferenceLiteral x:TypeArguments="mxs:OptionSetValue">
+            <mxs:OptionSetValue ExtensionData="{x:Null}" Value="0" />
+          </mxswa:ReferenceLiteral>
+        </InArgument>
+      </mxswa:SetState.State>
+      <mxswa:SetState.Status>
+        <InArgument x:TypeArguments="mxs:OptionSetValue">
+          <mxswa:ReferenceLiteral x:TypeArguments="mxs:OptionSetValue">
+            <mxs:OptionSetValue ExtensionData="{x:Null}" Value="353400000" />
+          </mxswa:ReferenceLiteral>
+        </InArgument>
+      </mxswa:SetState.Status>
+    </mxswa:SetState>
     <Sequence DisplayName="UpdateStep3: Set 'Approved By' and 'Approved On'">
       <Sequence.Variables>
         <Variable x:TypeArguments="x:Object" Name="UpdateStep3_1" />

--- a/src/solutions/devhub_DevelopmentHub_Develop/Extract/Workflows/Approve-38601740-AE0B-46AF-8809-5D402B5A0A02.xaml.data.xml
+++ b/src/solutions/devhub_DevelopmentHub_Develop/Extract/Workflows/Approve-38601740-AE0B-46AF-8809-5D402B5A0A02.xaml.data.xml
@@ -17,7 +17,7 @@
   <RunAs>1</RunAs>
   <SdkMessageId>{cd1166f8-b584-e911-a97e-0022480186c3}</SdkMessageId>
   <UniqueName>Approve</UniqueName>
-  <IsTransacted>0</IsTransacted>
+  <IsTransacted>1</IsTransacted>
   <IntroducedVersion>0.1.13.0</IntroducedVersion>
   <IsCustomizable>1</IsCustomizable>
   <FormId>{00000000-0000-0000-0000-000000000000}</FormId>

--- a/src/solutions/devhub_DevelopmentHub_Develop/WebResources/Scripts/src/develop.solutionmerge.ribbon.ts
+++ b/src/solutions/devhub_DevelopmentHub_Develop/WebResources/Scripts/src/develop.solutionmerge.ribbon.ts
@@ -83,10 +83,6 @@ namespace DevelopmentHub.Develop {
 
     executeWebApiRequest(new ApproveRequest(entity), 'Approving solution merge.')
       .then(async () => {
-        // Flows don't trigger for updates done within actions/workflows.
-        // Setting the statuscode here as a workaround
-        primaryControl.getAttribute('statuscode').setValue(353400000);
-        await primaryControl.data.save();
         primaryControl.data.refresh(false);
       });
   }


### PR DESCRIPTION
## Purpose
Fixes #24, which was due to the fact that we were updating the status reason to 'Approved' and then setting 'Approved By' to 'Modified By'. 

## Approach
Sets the status to reason to 'Approved' before setting 'Approved By' to 'Modified By'.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
