### PR TITLE
fix: patch version not reset on minor increment

### DIFF
--- a/src/solutions/devhub_DevelopmentHub_Develop/Extract/Workflows/GetPostMergeSolutionVersion-7859F1DF-DE44-4B3E-854F-BF25345A700A.xaml
+++ b/src/solutions/devhub_DevelopmentHub_Develop/Extract/Workflows/GetPostMergeSolutionVersion-7859F1DF-DE44-4B3E-854F-BF25345A700A.xaml
@@ -186,20 +186,12 @@
                     <Sequence DisplayName="AssignOutputArgumentStep7: Assign 'Patch Version'">
                       <Sequence.Variables>
                         <Variable x:TypeArguments="x:Object" Name="AssignOutputArgumentStep7_1" />
-                        <Variable x:TypeArguments="x:Object" Name="AssignOutputArgumentStep7_2" />
                         <Variable x:TypeArguments="x:String" Default="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" Name="TypeName" />
                       </Sequence.Variables>
-                      <mxswa:GetEntityProperty Attribute="devhub_patchversion" Entity="[InputEntities(&quot;related_devhub_targetsolution#devhub_solution&quot;)]" EntityName="devhub_solution" Value="[AssignOutputArgumentStep7_2]">
-                        <mxswa:GetEntityProperty.TargetType>
-                          <InArgument x:TypeArguments="s:Type">
-                            <mxswa:ReferenceLiteral x:TypeArguments="s:Type" Value="x:Int32" />
-                          </InArgument>
-                        </mxswa:GetEntityProperty.TargetType>
-                      </mxswa:GetEntityProperty>
                       <mxswa:ActivityReference AssemblyQualifiedName="Microsoft.Crm.Workflow.Activities.EvaluateExpression, Microsoft.Crm.Workflow, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" DisplayName="EvaluateExpression">
                         <mxswa:ActivityReference.Arguments>
-                          <InArgument x:TypeArguments="x:String" x:Key="ExpressionOperator">SelectFirstNonNull</InArgument>
-                          <InArgument x:TypeArguments="s:Object[]" x:Key="Parameters">[New Object() { AssignOutputArgumentStep7_2 }]</InArgument>
+                          <InArgument x:TypeArguments="x:String" x:Key="ExpressionOperator">CreateCrmType</InArgument>
+                          <InArgument x:TypeArguments="s:Object[]" x:Key="Parameters">[New Object() { Microsoft.Xrm.Sdk.Workflow.WorkflowPropertyType.Integer, "0" }]</InArgument>
                           <InArgument x:TypeArguments="s:Type" x:Key="TargetType">
                             <mxswa:ReferenceLiteral x:TypeArguments="s:Type" Value="x:Int32" />
                           </InArgument>


### PR DESCRIPTION
## Purpose
Fixes #20. When getting the next version for a solution merge, the patch version wasn't being set to 0 when the minor version was incremented.

## Approach
Updated `devhub_GetPostMergeSolutionVersion` action to set patch version to 0 when minor is incremented.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
