### PR TITLE
feat: detect potential solution merge conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ You must provide several package deployer settings parameters. Refer to the help
 
 ```powershell
 $settings = [PSCustomObject]@{
-  ApprovalsConnectionName = '<the connection name of the Approvals connection>'
-  AzureDevOpsConnectionName = '<the connection name of the Azure DevOps connection>'
-  AzureDevOpsOrganisation = '<the name of the Azure DevOps organisation>'
-  SolutionPublisherPrefix = '<the prefix of the publisher (without leading underscore)>'
+  'ConnRef:devhub_sharedapprovals_6d3fc' = '<the connection name of the Approvals connection>'
+  'ConnRef:devhub_sharedvisualstudioteamservices_bf2bc' = '<the connection name of the Azure DevOps connection>'
+  'AzureDevOpsOrganisation' = '<the name of the Azure DevOps organisation>'
+  'SolutionPublisherPrefix' = '<the prefix of the publisher (without leading underscore)>'
 }
 $settingsArray = $obj.PSObject.Properties | ForEach-Object { "$($_.Name)=$($_.Value)" }
 $runtimePackageSettings = [string]::Join("|", $settingsArray)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $settings = [PSCustomObject]@{
   'AzureDevOpsOrganisation' = '<the name of the Azure DevOps organisation>'
   'SolutionPublisherPrefix' = '<the prefix of the publisher (without leading underscore)>'
 }
-$settingsArray = $obj.PSObject.Properties | ForEach-Object { "$($_.Name)=$($_.Value)" }
+$settingsArray = $settings.PSObject.Properties | ForEach-Object { "$($_.Name)=$($_.Value)" }
 $runtimePackageSettings = [string]::Join("|", $settingsArray)
 
 Import-CrmPackage -PackageInformation $packages[0] -CrmConnection $conn -RuntimePackageSettings $runtimePackageSettings

--- a/deploy/DevelopmentHub.Deployment.csproj
+++ b/deploy/DevelopmentHub.Deployment.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Capgemini.PowerApps.PackageDeployerTemplate" Version="0.2.2" />
+    <PackageReference Include="Capgemini.PowerApps.PackageDeployerTemplate" Version="0.2.3" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationFramework" />

--- a/deploy/DevelopmentHub.Deployment.csproj
+++ b/deploy/DevelopmentHub.Deployment.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Capgemini.PowerApps.PackageDeployerTemplate" Version="0.2.3" />
+    <PackageReference Include="Capgemini.PowerApps.PackageDeployerTemplate" Version="0.2.4" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationFramework" />

--- a/deploy/PackageTemplate.cs
+++ b/deploy/PackageTemplate.cs
@@ -2,6 +2,7 @@ namespace DevelopmentHub.Deployment
 {
     using System;
     using System.ComponentModel.Composition;
+    using System.Diagnostics;
     using Capgemini.PowerApps.PackageDeployerTemplate;
     using Microsoft.Xrm.Tooling.PackageDeployment.CrmPackageExtentionBase;
 
@@ -137,7 +138,7 @@ namespace DevelopmentHub.Deployment
         /// <inheritdoc />
         public override UserRequestedImportAction OverrideSolutionImportDecision(string solutionUniqueName, Version organizationVersion, Version packageSolutionVersion, Version inboundSolutionVersion, Version deployedSolutionVersion, ImportAction systemSelectedImportAction)
         {
-            if (this.ForceImportOnSameVersion && systemSelectedImportAction == ImportAction.SkipSameVersion)
+            if (this.ForceImportOnSameVersion && (systemSelectedImportAction == ImportAction.SkipSameVersion || systemSelectedImportAction == ImportAction.SkipLowerVersion))
             {
                 return UserRequestedImportAction.ForceUpdate;
             }

--- a/deploy/PackageTemplate.cs
+++ b/deploy/PackageTemplate.cs
@@ -2,7 +2,6 @@ namespace DevelopmentHub.Deployment
 {
     using System;
     using System.ComponentModel.Composition;
-    using System.Diagnostics;
     using Capgemini.PowerApps.PackageDeployerTemplate;
     using Microsoft.Xrm.Tooling.PackageDeployment.CrmPackageExtentionBase;
 

--- a/deploy/PkgFolder/ImportConfig.xml
+++ b/deploy/PkgFolder/ImportConfig.xml
@@ -5,4 +5,5 @@
     <configsolutionfile overwriteunmanagedcustomizations="false" publishworkflowsandactivateplugins="true" solutionpackagefilename="devhub_DevelopmentHub_Develop.zip" />
     <configsolutionfile overwriteunmanagedcustomizations="false" publishworkflowsandactivateplugins="true" solutionpackagefilename="devhub_DevelopmentHub_AzureDevOps.zip" />
   </solutions>
+  <templateconfig />
 </configdatastorage>

--- a/templates/include-build-stage.yml
+++ b/templates/include-build-stage.yml
@@ -48,7 +48,7 @@ stages:
               projectVersion: '$(GitVersion.SemVer)'
               extraProperties: |
                 sonar.eslint.reportPaths=$(Build.SourcesDirectory)/src/solutions/devhub_DevelopmentHub_Develop/WebResources/Scripts/test_results/analysis/eslint.json
-                sonar.coverage.exclusions=src/solutions/**/*.ts
+                sonar.coverage.exclusions=src/solutions/**/*.ts, deploy/**/*.cs
           - task: PowerShell@2
             displayName: 'Build package'
             inputs:

--- a/templates/include-build-stage.yml
+++ b/templates/include-build-stage.yml
@@ -48,6 +48,7 @@ stages:
               projectVersion: '$(GitVersion.SemVer)'
               extraProperties: |
                 sonar.eslint.reportPaths=$(Build.SourcesDirectory)/src/solutions/devhub_DevelopmentHub_Develop/WebResources/Scripts/test_results/analysis/eslint.json
+                sonar.coverage.exclusions=src/solutions/**/*.ts
           - task: PowerShell@2
             displayName: 'Build package'
             inputs:


### PR DESCRIPTION
## Purpose
We have issues with changes being made to the same components simultaneously with large teams. The goal is to prevent this from happening altogether (#9) but platform limitations mean that we do not yet have a solution for this. However, we may be able to prevent some of these conflicts from being merged if we can notify at the approval stage.

## Approach
When approving a solution merge, a confirmation dialog will appear if any of the solution components in the development solution have been found in any other development solutions. The confirmation dialog will also include the offending solution names.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
