### PR TITLE
build: fix build when repo path includes spaces

### DIFF
--- a/deploy/DevelopmentHub.Deployment.csproj
+++ b/deploy/DevelopmentHub.Deployment.csproj
@@ -15,7 +15,7 @@
     <SolutionProjectsToBuild Include="../src/**/*.cdsproj" Visible="false" />
   </ItemGroup>
   <Target Condition="'$(Configuration)'!='Test'" Name="PackSolutions" BeforeTargets="Build">
-    <Exec Command="dotnet build %(SolutionProjectsToBuild.FullPath) --configuration $(Configuration)" />
+    <Exec Command="dotnet build &quot;%(SolutionProjectsToBuild.FullPath)&quot; --configuration $(Configuration)" />
     <!-- Using Exec as the MSBuild task was failing from a clean build.
     <MSBuild Projects="@(SolutionProjectsToBuild)" Targets="Restore" />
     <MSBuild Projects="@(SolutionProjectsToBuild)" Targets="Build" /> -->


### PR DESCRIPTION
 Cloning solution into folder with spaces in the path

## Purpose
Allow the clone solution into folder with spaces in the path

## Approach
replace line:
<Exec Command="dotnet build %(SolutionProjectsToBuild.FullPath) --configuration $(Configuration)" />
with
<Exec Command="dotnet build &quot;%(SolutionProjectsToBuild.FullPath)&quot; --configuration $(Configuration)" />
